### PR TITLE
Add support for `riscv64`

### DIFF
--- a/sys_linux_riscv64.go
+++ b/sys_linux_riscv64.go
@@ -1,0 +1,10 @@
+// Copyright 2017 Mikio Hara. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tcp
+
+const (
+	sysSIOCINQ  = 0x541b
+	sysSIOCOUTQ = 0x5411
+)


### PR DESCRIPTION
`sys_linux_riscv64.go` is based on `sys_linux_amd64.go` from `mikioh/tcp` and `ioctl.h` from Linux RISC-V.